### PR TITLE
[feature/#8] Fixed github_bot import

### DIFF
--- a/sites/_snippets.inc
+++ b/sites/_snippets.inc
@@ -617,6 +617,15 @@
 
 # GitHub webhook endpoint handler - lenient rate limits for GitHub's IPs
 (github_bot_webhook_handler) {
+    # Only allow POST requests (GitHub webhooks only use POST)
+    @not_post {
+        not method POST
+    }
+
+    handle @not_post {
+        respond "Method Not Allowed - Webhooks must use POST" 405
+    }
+
     # Match GitHub webhook requests by User-Agent
     # GitHub webhooks identify as "GitHub-Hookshot/*"
     @github_webhook {

--- a/sites/github-bot.example
+++ b/sites/github-bot.example
@@ -36,27 +36,9 @@ bot.example.com {
     handle /webhook {
         import github_bot_webhook_handler
 
-        # Only allow POST requests for webhooks
-        @webhook_post {
-            method POST
-        }
-
-        @not_post {
-            not method POST
-        }
-
-        handle @not_post {
-            respond "Method Not Allowed - Webhooks must use POST" 405
-        }
-
-        handle @webhook_post {
-            # Proxy to your bot application
-            # Your app should verify the X-Hub-Signature-256 header
-            reverse_proxy localhost:3000 {
-                # Pass webhook-specific headers
-                header_up X-Webhook-Endpoint "true"
-            }
-        }
+        # Proxy to your bot application
+        # Your app should verify the X-Hub-Signature-256 header
+        reverse_proxy localhost:3000
     }
 
     # Alternative path for webhooks (some setups use /webhooks plural)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the GitHub webhook handler only accepts POST requests and responds with HTTP 405 for unsupported methods.

<!-- kumpeapps-issue-autoclose -->
Closes #8