### PR TITLE
[feature/#15] Fixed

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,6 +2,47 @@
 	# Set a real email via ACME_EMAIL at runtime.
 	email {$ACME_EMAIL}
 	acme_ca https://acme-v02.api.letsencrypt.org/directory
+
+	# Global error handling for all sites
+	# Shows custom error pages automatically without needing to add them to each site
+	servers {
+		protocols h1 h2 h3
+	}
+}
+
+# Global error page handling
+# This applies to all sites unless they define their own handle_errors
+(auto_error_pages) {
+	handle_errors {
+		@404 expression {http.error.status_code} == 404
+		@502 expression {http.error.status_code} == 502
+		@503 expression {http.error.status_code} == 503
+		@504 expression {http.error.status_code} == 504
+
+		handle @404 {
+			rewrite * /404.html
+			root * /usr/local/share/caddy/error-pages
+			file_server
+		}
+
+		handle @502 {
+			rewrite * /502.html
+			root * /usr/local/share/caddy/error-pages
+			file_server
+		}
+
+		handle @503 {
+			rewrite * /503.html
+			root * /usr/local/share/caddy/error-pages
+			file_server
+		}
+
+		handle @504 {
+			rewrite * /504.html
+			root * /usr/local/share/caddy/error-pages
+			file_server
+		}
+	}
 }
 
 # Import reusable snippets globally

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ See [sites/example-with-snippets.caddy](sites/example-with-snippets.caddy) for c
 
 Professional, user-friendly error pages with modern responsive design similar to BunkerWeb.
 
+### Automatic Error Handling
+
+**Error pages are now enabled automatically!** The docker-entrypoint.sh automatically injects error handling into all site configurations at startup. No manual configuration needed.
+
 ### Available Error Pages
 
 - **404** - Page or domain not found (blue theme)
@@ -576,32 +580,40 @@ Professional, user-friendly error pages with modern responsive design similar to
 - **503** - Service Unavailable - maintenance/high load (pink theme)
 - **504** - Gateway Timeout - upstream timeout (orange theme)
 
-### Usage
+### How It Works
 
-Import error page snippets in your site configuration:
+1. **Unconfigured domains**: Automatically show 404 error page via `000-fallback.caddy`
+2. **Configured domains**: The entrypoint script automatically adds error handling to all `.caddy` files that don't already have it
+3. **Manual override**: Add your own `handle_errors` block or `import error_pages_*` to customize
+
+### Manual Configuration (Optional)
+
+If you want to customize error handling, you can manually import these snippets:
 
 ```caddyfile
 example.com {
-    # Show custom error pages for backend errors (recommended for reverse proxies)
+    # Option 1: All error codes (recommended)
+    import error_pages_all
+
+    # Option 2: Only backend errors (502, 503, 504)
     import error_pages_backend
 
+    # Option 3: Only 404 errors
+    import error_pages_404
+
+    # Your other configuration
     reverse_proxy localhost:8080
 }
 ```
 
-Available snippets:
+**Note:** If you add manual error handling, the automatic injection will be skipped for that file.
 
-- `error_pages_backend` - Handles 502, 503, 504 (backend/upstream errors)
-- `error_pages_404` - Handles 404 (page not found)
-- `error_pages_all` - Handles all common error codes (404, 502, 503, 504)
+### Disabling Automatic Injection
 
-### Unconfigured Domains
+The automatic error handling injection only works with writable /sites volumes. To disable:
 
-The setup includes a fallback handler (`000-fallback.caddy`) that automatically shows the 404 error page for any domain not explicitly configured in your Caddy setup.
-
-### Error Page Features
-
-- 📱 Fully responsive design
+1. Mount `/sites` as read-only (`:ro`)
+2. Or add `handle_errors` or `import.*error_pages` to your config (prevents injection)
 - 🎨 Modern gradient backgrounds (unique color for each error)
 - 💡 User-friendly guidance and troubleshooting tips
 - 🔄 "Try Again" button for easy refresh
@@ -810,27 +822,37 @@ chmod +x safe-reload.sh
 - ✅ Validates each site config individually
 - ✅ Identifies which configs have errors
 - ✅ Shows detailed error messages
-- ✅ Multiple handling modes: backup, delete with prompt, or auto-delete
+- ✅ **Smart default: Temporarily hides invalid configs during reload**
+- ✅ Multiple handling modes: temporary hide, backup, or delete
 - ✅ Detects read-only mounts and adapts behavior
 - ✅ Optionally moves invalid configs to backup directory with timestamps
 - ✅ Optionally deletes invalid configs (with or without confirmation)
-- ✅ Only reloads Caddy if all remaining configs are valid
+- ✅ Only reloads Caddy with valid configs
 - ✅ Keeps error logs alongside backups for troubleshooting
 
 **Handling Modes:**
 
-- **No flags** - Validates and reports errors, requires manual action
-- **`--auto-backup`** - Automatically moves invalid configs to timestamped backup directory (safest)
+- **No flags (Default - Recommended)** - Temporarily renames invalid configs to `.caddy.invalid` during reload, then restores them. This allows Caddy to reload with valid sites while preserving broken configs for you to fix later. **No data loss!**
+
+- **`--auto-backup`** - Permanently moves invalid configs to timestamped backup directory (safest for long-term storage)
+
 - **`--delete`** - Deletes invalid configs after confirmation prompt
+
 - **`--auto-delete`** - Automatically deletes invalid configs without prompt (use with caution)
 
 **When to use each mode:**
 
-- Use **`--auto-backup`** (recommended) when:
-  - You want to keep invalid configs for reference
+- Use **default (no flags)** (recommended) when:
+  - You have a mix of working and broken configs
+  - You want Caddy to keep running with valid sites
+  - You want to fix invalid configs without losing them
+  - You need Caddy to reload immediately without manual intervention
+
+- Use **`--auto-backup`** when:
+  - You want to archive old/invalid configs permanently
   - You're still developing/testing configurations
   - You need an audit trail of changes
-  - You want the safest option with easy rollback
+  - You want timestamped backups for historical reference
 
 - Use **`--delete`** when:
   - You want to remove invalid configs but verify first

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,8 +18,43 @@ if [ -w "${sites_dir}" ] || mkdir -p "${sites_dir}" 2>/dev/null; then
     if [ ! -f "${redirect_dst}" ]; then
         cp "${redirect_src}" "${redirect_dst}" 2>/dev/null || echo "Note: /sites is read-only, skipping example file copy"
     fi
+
+    # Auto-inject error handling into site configs that don't already have it
+    # This makes error pages automatic without needing manual configuration
+    echo "Checking site configs for error handling..."
+    for config_file in "${sites_dir}"/*.caddy; do
+        # Skip if no .caddy files exist or if it's an example file
+        if [ ! -f "$config_file" ] || [ "$config_file" = "${sites_dir}/*.caddy" ]; then
+            continue
+        fi
+
+        filename=$(basename "$config_file")
+
+        # Skip example files and special configs
+        case "$filename" in
+            *.example|000-fallback.caddy)
+                continue
+                ;;
+        esac
+
+        # Check if file already has error handling
+        if ! grep -q "handle_errors\|import.*error_pages\|import auto_error_pages" "$config_file"; then
+            echo "  Adding automatic error handling to: $filename"
+            # Create temp file with error handling injected before the closing brace
+            # Find the last closing brace and inject error handling before it
+            awk '
+            /^}$/ && !done {
+                print "    # Auto-injected error handling (remove this and add your own if needed)"
+                print "    import auto_error_pages"
+                print ""
+                done=1
+            }
+            { print }
+            ' "$config_file" > "$config_file.tmp" && mv "$config_file.tmp" "$config_file"
+        fi
+    done
 else
-    echo "Note: /sites is read-only, skipping example file creation"
+    echo "Note: /sites is read-only, skipping example file creation and auto-injection"
 fi
 
 if [ "$#" -eq 0 ]; then

--- a/safe-reload.sh
+++ b/safe-reload.sh
@@ -11,20 +11,24 @@ if [ -f "/.dockerenv" ] && [ -d "/sites" ]; then
     DEFAULT_SITES_DIR="/sites"
     DEFAULT_BACKUP_DIR="/sites-backup"
     DEFAULT_CADDYFILE="/etc/caddy/Caddyfile"
+    DEFAULT_SNIPPETS_DIR="/usr/local/share/caddy"
 else
     # Running in dev container or locally
     DEFAULT_SITES_DIR="/workspaces/caddy/sites"
     DEFAULT_BACKUP_DIR="/workspaces/caddy/sites-backup"
     DEFAULT_CADDYFILE="/workspaces/caddy/Caddyfile"
+    DEFAULT_SNIPPETS_DIR="/workspaces/caddy/sites"
 fi
 
 CADDY_BINARY="${CADDY_BINARY:-caddy}"
 SITES_DIR="${SITES_DIR:-$DEFAULT_SITES_DIR}"
 BACKUP_DIR="${BACKUP_DIR:-$DEFAULT_BACKUP_DIR}"
 MAIN_CADDYFILE="${MAIN_CADDYFILE:-$DEFAULT_CADDYFILE}"
+SNIPPETS_DIR="${SNIPPETS_DIR:-$DEFAULT_SNIPPETS_DIR}"
 AUTO_BACKUP=false
 AUTO_DELETE=false
 DELETE_PROMPT=false
+RESTORE_INVALID=false
 TEMP_DIR=$(mktemp -d)
 
 # Parse arguments
@@ -44,6 +48,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Default behavior (no options):"
+            echo "  Validates all configs, temporarily hides invalid ones, reloads Caddy"
+            echo "  with valid configs only, then restores invalid configs so you can fix them."
+            echo "  This allows Caddy to run with valid sites while preserving broken configs."
             echo ""
             echo "Options:"
             echo "  --auto-backup    Automatically move invalid configs to backup directory"
@@ -176,8 +185,8 @@ while IFS= read -r -d '' config_file; do
     # Test validation
 }
 
-import $SITES_DIR/_snippets.inc
-import $SITES_DIR/_matchers.inc
+import $SNIPPETS_DIR/_snippets.inc
+import $SNIPPETS_DIR/_matchers.inc
 import $config_file
 EOF
 
@@ -214,16 +223,18 @@ if [ ${#invalid_configs[@]} -gt 0 ]; then
     if [ "$IS_READONLY" = true ]; then
         echo -e "${RED}Cannot proceed with read-only mount.${NC}"
         echo ""
-        echo "With read-only mounts, you must:"
+        echo "With read-only mounts, invalid configs cannot be temporarily hidden."
+        echo ""
+        echo "You must:"
         echo "  1. Fix the errors in your source repository"
         echo "  2. Commit and push the changes"
         echo "  3. Redeploy/remount the updated configs"
         echo "  4. Run this script again"
         echo ""
-        echo "Alternatively, to temporarily exclude these configs:"
+        echo "Or permanently exclude these configs:"
         echo "  - Rename them to *.example in your source"
         echo "  - Remove them from your source"
-        echo "  - Use import globs that exclude them"
+        echo "  - Update import globs to exclude them"
         exit 1
     elif [ "$AUTO_BACKUP" = true ]; then
         echo -e "${YELLOW}Auto-backup enabled. Moving invalid configs...${NC}"
@@ -284,14 +295,26 @@ if [ ${#invalid_configs[@]} -gt 0 ]; then
             exit 1
         fi
     else
-        echo -e "${YELLOW}Invalid configs found but auto-backup disabled.${NC}"
-        echo "Options:"
-        echo "  1. Run with --auto-backup to automatically move invalid configs"
-        echo "  2. Run with --auto-delete to automatically delete invalid configs"
-        echo "  3. Run with --delete to delete with confirmation prompt"
-        echo "  4. Manually fix or remove invalid configs"
-        echo "  5. Rename them to *.example to exclude from loading"
-        exit 1
+        echo -e "${YELLOW}Invalid configs found. Using safe reload mode.${NC}"
+        echo "Temporarily renaming invalid configs so Caddy can reload with valid ones..."
+        echo ""
+
+        # Temporarily rename invalid configs
+        for config in "${invalid_configs[@]}"; do
+            filename=$(basename "$config")
+            mv "$config" "${config}.invalid"
+            echo -e "  ${YELLOW}Renamed:${NC} $filename → ${filename}.invalid (temporary)"
+        done
+        echo ""
+        echo -e "${GREEN}Caddy will reload with valid configs only.${NC}"
+        echo -e "${YELLOW}Invalid configs preserved for you to fix later.${NC}"
+        echo ""
+        echo "After reload, invalid configs will be renamed back to .caddy"
+        echo "You can fix them and run safe-reload.sh again."
+        echo ""
+
+        # Set flag to rename them back after reload
+        RESTORE_INVALID=true
     fi
 fi
 
@@ -300,7 +323,21 @@ echo "Reloading Caddy..."
 if "$CADDY_BINARY" reload --config "$MAIN_CADDYFILE" --adapter caddyfile; then
     echo -e "${GREEN}✓ Caddy reloaded successfully!${NC}"
 
-    if [ ${#invalid_configs[@]} -gt 0 ]; then
+    # Restore temporarily renamed invalid configs
+    if [ "$RESTORE_INVALID" = true ]; then
+        echo ""
+        echo "Restoring invalid configs to original names..."
+        for config in "${invalid_configs[@]}"; do
+            if [ -f "${config}.invalid" ]; then
+                filename=$(basename "$config")
+                mv "${config}.invalid" "$config"
+                echo -e "  ${GREEN}Restored:${NC} ${filename}.invalid → $filename"
+            fi
+        done
+        echo ""
+        echo -e "${YELLOW}Note: ${#invalid_configs[@]} invalid config(s) are present but ignored by Caddy${NC}"
+        echo "Fix the errors and run safe-reload.sh again to include them."
+    elif [ ${#invalid_configs[@]} -gt 0 ]; then
         echo ""
         if [ "$AUTO_BACKUP" = true ]; then
             echo -e "${YELLOW}Note: ${#invalid_configs[@]} config(s) were backed up and excluded${NC}"
@@ -311,5 +348,15 @@ if "$CADDY_BINARY" reload --config "$MAIN_CADDYFILE" --adapter caddyfile; then
     fi
 else
     echo -e "${RED}✗ Caddy reload failed${NC}"
+
+    # Restore invalid configs if reload failed
+    if [ "$RESTORE_INVALID" = true ]; then
+        echo "Restoring temporarily renamed configs..."
+        for config in "${invalid_configs[@]}"; do
+            if [ -f "${config}.invalid" ]; then
+                mv "${config}.invalid" "$config"
+            fi
+        done
+    fi
     exit 1
 fi

--- a/sites/000-fallback.caddy
+++ b/sites/000-fallback.caddy
@@ -1,15 +1,36 @@
 # Fallback handler for unconfigured domains
 # This catches all requests that don't match any configured site
-# and shows a friendly 404 error page
+# and shows a friendly error page for ALL error types
 
 # Catch-all for any domain not explicitly configured
 :80, :443 {
-    # Error handling for unconfigured domains
+    # Comprehensive error handling for ALL error codes
     handle_errors {
         @404 expression {http.error.status_code} == 404
+        @502 expression {http.error.status_code} == 502
+        @503 expression {http.error.status_code} == 503
+        @504 expression {http.error.status_code} == 504
 
         handle @404 {
             rewrite * /404.html
+            root * /usr/local/share/caddy/error-pages
+            file_server
+        }
+
+        handle @502 {
+            rewrite * /502.html
+            root * /usr/local/share/caddy/error-pages
+            file_server
+        }
+
+        handle @503 {
+            rewrite * /503.html
+            root * /usr/local/share/caddy/error-pages
+            file_server
+        }
+
+        handle @504 {
+            rewrite * /504.html
             root * /usr/local/share/caddy/error-pages
             file_server
         }

--- a/validate-config.sh
+++ b/validate-config.sh
@@ -10,15 +10,18 @@ if [ -f "/.dockerenv" ] && [ -d "/sites" ]; then
     # Running in Docker container
     DEFAULT_SITES_DIR="/sites"
     DEFAULT_CADDYFILE="/etc/caddy/Caddyfile"
+    DEFAULT_SNIPPETS_DIR="/usr/local/share/caddy"
 else
     # Running in dev container or locally
     DEFAULT_SITES_DIR="/workspaces/caddy/sites"
     DEFAULT_CADDYFILE="/workspaces/caddy/Caddyfile"
+    DEFAULT_SNIPPETS_DIR="/workspaces/caddy/sites"
 fi
 
 CADDY_BINARY="${CADDY_BINARY:-caddy}"
 SITES_DIR="${SITES_DIR:-$DEFAULT_SITES_DIR}"
 MAIN_CADDYFILE="${MAIN_CADDYFILE:-$DEFAULT_CADDYFILE}"
+SNIPPETS_DIR="${SNIPPETS_DIR:-$DEFAULT_SNIPPETS_DIR}"
 TEMP_DIR=$(mktemp -d)
 
 # Colors for output
@@ -94,8 +97,8 @@ if [ -d "$SITES_DIR" ]; then
     # Test validation
 }
 
-import $SITES_DIR/_snippets.inc
-import $SITES_DIR/_matchers.inc
+import $SNIPPETS_DIR/_snippets.inc
+import $SNIPPETS_DIR/_matchers.inc
 import $config_file
 EOF
 


### PR DESCRIPTION
## Summary by Sourcery

Add automatic error handling injection for site configs, improve safe reload behavior for invalid configs, and update scripts and docs to use shared snippets locations and describe the new defaults.

New Features:
- Automatically inject error handling snippets into writable site configurations at container startup so error pages work without manual configuration.
- Introduce a default safe reload mode that temporarily hides invalid configs during reload while preserving them for later fixes.

Enhancements:
- Allow overriding a dedicated snippets directory for shared Caddy includes in validation and reload scripts instead of using the sites directory.
- Clarify read-only mount messaging and options when invalid configs are detected during safe reload.

Documentation:
- Document automatic error handling behavior, manual override options, and how to disable auto-injection in the README.
- Update safe-reload.sh documentation to describe the new default behavior and revised handling modes.

<!-- kumpeapps-issue-autoclose -->
Closes #15