### PR TITLE
[bug/#22] Fixed logo issues and added global-asseets directory

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -13,6 +13,20 @@
 # Global error page handling
 # This applies to all sites unless they define their own handle_errors
 (auto_error_pages) {
+	# Serve error page assets (logo, etc.)
+	handle /error-assets/* {
+		uri strip_prefix /error-assets
+		root * /usr/local/share/caddy/error-pages
+		file_server
+	}
+
+	# Serve global assets (shared across all sites)
+	handle /global-assets/* {
+		uri strip_prefix /global-assets
+		root * /usr/local/share/caddy/sites/global-assets
+		file_server
+	}
+
 	handle_errors {
 		@404 expression {http.error.status_code} == 404
 		@502 expression {http.error.status_code} == 502

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 # Alpine base image only includes /bin/sh by default
 RUN apk add --no-cache bash
 
-RUN mkdir -p /sites /sites-backup /usr/local/share/caddy
+RUN mkdir -p /sites /sites-backup /usr/local/share/caddy /usr/local/share/caddy/sites/global-assets
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY sites/caddy.example /usr/local/share/caddy/caddy.example
 COPY sites/redirect.example /usr/local/share/caddy/redirect.example

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,13 @@ if [ -w "${sites_dir}" ] || mkdir -p "${sites_dir}" 2>/dev/null; then
         cp "${redirect_src}" "${redirect_dst}" 2>/dev/null || echo "Note: /sites is read-only, skipping example file copy"
     fi
 
+    # Create global-assets directory if it doesn't exist
+    global_assets_dir="${sites_dir}/global-assets"
+    if [ ! -d "${global_assets_dir}" ]; then
+        mkdir -p "${global_assets_dir}" 2>/dev/null || echo "Note: Failed to create global-assets directory"
+        echo "Created global-assets directory at ${global_assets_dir}"
+    fi
+
     # Auto-inject error handling into site configs that don't already have it
     # This makes error pages automatic without needing manual configuration
     echo "Checking site configs for error handling..."

--- a/error-pages/404.html
+++ b/error-pages/404.html
@@ -217,7 +217,7 @@
 <body>
     <div class="container">
         <div class="logo">
-            <img src="./logo.png" alt="Kumpe Apps">
+            <img src="/error-assets/logo.png" alt="Kumpe Apps">
         </div>
 
         <div class="kicker">Error 404</div>

--- a/error-pages/502.html
+++ b/error-pages/502.html
@@ -217,7 +217,7 @@
 <body>
     <div class="container">
         <div class="logo">
-            <img src="./logo.png" alt="Kumpe Apps">
+            <img src="/error-assets/logo.png" alt="Kumpe Apps">
         </div>
 
         <div class="kicker">Error 502</div>

--- a/error-pages/503.html
+++ b/error-pages/503.html
@@ -221,7 +221,7 @@
 <body>
     <div class="container">
         <div class="logo">
-            <img src="./logo.png" alt="Kumpe Apps">
+            <img src="/error-assets/logo.png" alt="Kumpe Apps">
         </div>
 
         <div class="kicker">Error 503</div>

--- a/error-pages/504.html
+++ b/error-pages/504.html
@@ -221,7 +221,7 @@
 <body>
     <div class="container">
         <div class="logo">
-            <img src="./logo.png" alt="Kumpe Apps">
+            <img src="/error-assets/logo.png" alt="Kumpe Apps">
         </div>
 
         <div class="kicker">Error 504</div>


### PR DESCRIPTION
## Summary by Sourcery

Ensure error page logos load correctly and provision a shared global-assets directory for Caddy sites.

Bug Fixes:
- Update error page logo image paths to use the correct /error-assets location so logos render properly.

Enhancements:
- Create a global-assets directory under /sites at runtime and via Docker image initialization for shared static resources.

<!-- kumpeapps-issue-autoclose -->
Closes #22