### PR TITLE
[feature/#30] Added Site Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Simply use any snippet with the `import` directive in your .caddy files:
 
 ```caddyfile
 your-domain.com {
-    import cloudns_dns
+    import ssl_defaults        # SSL + error pages + compression
     import security_headers
     import bot_protection
     import rate_limit_general
@@ -443,6 +443,31 @@ your-domain.com {
 ```
 
 ### Available Snippets
+
+#### Essential Defaults
+
+- `ssl_defaults` - **Recommended starting point** - Includes CloudNS DNS-01, error pages, and compression
+- `site_defaults` - Error pages and compression (no SSL config)
+- `minimal_defaults` - Just error pages, no extras
+
+**Quick Start:** Add `import ssl_defaults` to your site config to automatically get HTTPS with CloudNS DNS-01, custom error pages (404, 502, 503, 504), and compression. This is the recommended starting point for most sites.
+
+```caddyfile
+your-domain.com {
+    import ssl_defaults        # SSL + error pages + compression in one line
+    import security_headers
+
+    reverse_proxy http://localhost:8080
+}
+```
+
+If you need SSL with a different provider or want more control, use the individual snippets:
+
+```caddyfile
+your-domain.com {
+    import cloudns_dns         # or your own tls config
+    import site_defaults       # error pages + compression
+```
 
 #### Security
 
@@ -522,7 +547,7 @@ example.com {
     # Import matchers inside the site block
     import /usr/local/share/caddy/_matchers.inc
 
-    import cloudns_dns
+    import ssl_defaults
     import security_headers
 
     # Now you can use the matchers
@@ -542,9 +567,8 @@ example.com {
 
 ```caddyfile
 example.com {
-    import cloudns_dns
+    import ssl_defaults
     import security_headers
-    import compression
 
     # Block bots and exploits
     import bot_protection

--- a/sites/_snippets.inc
+++ b/sites/_snippets.inc
@@ -3,6 +3,24 @@
 # Then use individual snippets with: import snippet_name
 
 # =============================================================================
+# SITE DEFAULTS (includes error pages)
+# =============================================================================
+# Import this to get automatic error pages and other sensible defaults
+# Usage in your site config: import site_defaults
+(site_defaults) {
+    # Auto error pages - provides custom 404, 502, 503, 504 pages
+    import auto_error_pages
+
+    # Compression for better performance
+    import compression
+}
+
+# Minimal defaults (just error pages, no extras)
+(minimal_defaults) {
+    import auto_error_pages
+}
+
+# =============================================================================
 # SECURITY HEADERS
 # =============================================================================
 (security_headers) {
@@ -303,6 +321,14 @@
         propagation_timeout -1
         resolvers 1.1.1.1 8.8.8.8
     }
+}
+
+# SSL/HTTPS defaults with CloudNS
+# Combines CloudNS DNS-01 challenge with site defaults (error pages + compression)
+# This is the most common starting point for HTTPS sites
+(ssl_defaults) {
+    import cloudns_dns
+    import site_defaults
 }
 
 # =============================================================================

--- a/sites/caddy.example
+++ b/sites/caddy.example
@@ -6,8 +6,8 @@
 # Note: Snippets are automatically imported globally in Caddyfile
 
 www.example.com, example.com, privacy.example.com {
-    # Automatic HTTPS with CloudNS DNS-01 challenge
-    import cloudns_dns
+    # SSL/HTTPS + error pages + compression in one line
+    import ssl_defaults
 
     # Security headers for all responses
     import security_headers
@@ -21,17 +21,11 @@ www.example.com, example.com, privacy.example.com {
     # General rate limiting (300 req/min per IP)
     import rate_limit_general
 
-    # Enable compression
-    import compression
-
     # Cache static assets
     import static_cache
 
     # Enable logging
     import log_common
-
-    # Custom error pages for backend errors (502, 503, 504)
-    import error_pages_backend
 
     # Redirect apex domain to www
     import apex_to_www

--- a/sites/example-with-snippets.caddy.example
+++ b/sites/example-with-snippets.caddy.example
@@ -4,37 +4,34 @@
 # Matchers must be imported per-site or defined inline (as shown in these examples)
 
 # =============================================================================
-# EXAMPLE 1: Basic Website with Security
+# EXAMPLE 1: Basic Website with Security (Simplified)
 # =============================================================================
 www.example.com, example.com {
-    # CloudNS DNS-01 challenge
-    import cloudns_dns
-    
+    # SSL + error pages + compression in one line
+    import ssl_defaults
+
     # Redirect apex to www
     @apex host example.com
     redir @apex https://www.example.com{uri} permanent
-    
+
     # Security headers
     import security_headers
-    
+
     # Basic bot protection
     import bot_protection
-    
+
     # Exploit protection
     import exploit_protection
-    
+
     # General rate limiting
     import rate_limit_general
-    
-    # Compression
-    import compression
-    
+
     # Static asset caching
     import static_cache
-    
+
     # Logging
     import log_common
-    
+
     # Reverse proxy to application
     reverse_proxy http://127.0.0.1:8080 {
         import reverse_proxy_defaults
@@ -45,11 +42,10 @@ www.example.com, example.com {
 # EXAMPLE 2: API Server with CORS
 # =============================================================================
 api.example.com {
-    import cloudns_dns
+    import ssl_defaults
     import security_headers
     import bot_protection_strict
-    import compression
-    
+
     # API rate limiting
     @api path /api/*
     handle @api {
@@ -59,7 +55,7 @@ api.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # Login endpoint with strict rate limiting
     @login path /login /auth/*
     handle @login {
@@ -68,13 +64,13 @@ api.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # Health check (no rate limit)
     @health path /health /healthz
     handle @health {
         reverse_proxy http://127.0.0.1:3000
     }
-    
+
     # Default
     reverse_proxy http://127.0.0.1:3000 {
         import reverse_proxy_defaults
@@ -86,13 +82,13 @@ api.example.com {
 # =============================================================================
 static.example.com {
     import cloudns_dns
+    import site_defaults
     import security_headers
-    import compression
     import static_cache
-    
+
     # Lenient rate limiting for static content
     import rate_limit_lenient
-    
+
     root * /var/www/html
     import file_server_defaults
 }
@@ -102,17 +98,18 @@ static.example.com {
 # =============================================================================
 admin.example.com {
     import cloudns_dns
+    import site_defaults
     import security_headers_strict
     import exploit_protection
-    
+
     # Very strict rate limiting
     import rate_limit_strict
-    
+
     # Uncomment and configure basic auth
     # basicauth {
     #     admin $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
     # }
-    
+
     reverse_proxy http://127.0.0.1:9000 {
         import reverse_proxy_defaults
     }
@@ -128,7 +125,7 @@ shop.example.com {
     import exploit_protection
     import compression
     import log_detailed
-    
+
     # Admin section - protected
     @admin path /admin/*
     handle @admin {
@@ -138,7 +135,7 @@ shop.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # Checkout - strict rate limiting
     @checkout path /checkout /payment /order
     handle @checkout {
@@ -147,7 +144,7 @@ shop.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # API endpoints
     @api path /api/*
     handle @api {
@@ -157,7 +154,7 @@ shop.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # Static assets - aggressive caching
     handle @static_assets {
         import static_cache
@@ -165,7 +162,7 @@ shop.example.com {
             import reverse_proxy_defaults
         }
     }
-    
+
     # Default handler
     import rate_limit_general
     reverse_proxy http://127.0.0.1:8080 {


### PR DESCRIPTION
## Summary by Sourcery

Introduce reusable site default snippets for Caddy configurations and update documentation to promote their use as the recommended starting point for HTTPS sites.

New Features:
- Add site_defaults snippet providing shared error pages and compression for site configs.
- Add minimal_defaults snippet offering only custom error pages with no additional features.
- Add ssl_defaults snippet combining CloudNS DNS-01 SSL setup with site_defaults for a one-line HTTPS configuration.

Documentation:
- Document new essential default snippets (ssl_defaults, site_defaults, minimal_defaults) with usage examples and recommend ssl_defaults as the primary quick-start option.
- Update example Caddyfile configurations to use ssl_defaults instead of directly importing cloudns_dns and compression.

<!-- kumpeapps-issue-autoclose -->
Closes #30