### PR TITLE
[feature/#32] Added dev/stage env banner snippets

### DIFF
--- a/sites/_snippets.inc
+++ b/sites/_snippets.inc
@@ -21,6 +21,161 @@
 }
 
 # =============================================================================
+# ENVIRONMENT BANNERS
+# =============================================================================
+ # Wrap top-level browser HTML navigations in a visible environment frame while
+ # letting the site's normal handlers, including reverse_proxy, serve the app.
+ # Usage:
+ #     import dev_env
+ #     reverse_proxy http://127.0.0.1:8080
+(environment_banner) {
+    @environment_banner_frame path /_env_frame/*
+
+    @environment_banner_page {
+        method GET
+        not path /_env_frame/*
+        header Sec-Fetch-Dest document
+        header Accept *text/html*
+    }
+
+    # Route iframe requests to the normal site handlers after stripping the
+    # internal prefix used by the wrapper page.
+    uri @environment_banner_frame strip_prefix /_env_frame
+
+    # Allow the framed application to render even if the upstream sets headers
+    # that would block same-origin embedding.
+    header @environment_banner_frame -X-Frame-Options
+    header @environment_banner_frame -Content-Security-Policy
+
+    respond @environment_banner_page <<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,nofollow">
+    <title>{args[0]} Environment</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --env-accent: {args[1]};
+            --env-accent-soft: {args[2]};
+            --env-text: #1b1b1b;
+            --env-surface: #fffaf7;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(180deg, var(--env-accent-soft) 0%, #ffffff 160px);
+            color: var(--env-text);
+        }
+
+        body {
+            border: 8px solid var(--env-accent);
+        }
+
+        .env-shell {
+            min-height: 100vh;
+            display: grid;
+            grid-template-rows: auto 1fr;
+        }
+
+        .env-banner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.85rem 1.25rem;
+            background: var(--env-accent);
+            color: #ffffff;
+            font-size: 0.95rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
+        }
+
+        .env-banner strong {
+            font-size: 1rem;
+        }
+
+        .env-banner span {
+            opacity: 0.92;
+        }
+
+        .env-app {
+            min-height: 0;
+            padding: 0;
+        }
+
+        .env-app iframe {
+            display: block;
+            width: 100%;
+            height: calc(100vh - 66px);
+            border: 0;
+            background: #ffffff;
+        }
+
+        @media (max-width: 720px) {
+            body {
+                border-width: 6px;
+            }
+
+            .env-banner {
+                align-items: flex-start;
+                flex-direction: column;
+                padding: 0.9rem 1rem;
+            }
+
+            .env-app iframe {
+                height: calc(100vh - 92px);
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="env-shell">
+        <div class="env-banner">
+            <strong>{args[0]} environment</strong>
+            <span>Use this instance for testing only.</span>
+        </div>
+        <div class="env-app">
+            <iframe
+                src="/_env_frame{uri}"
+                title="{args[0]} environment application"
+                referrerpolicy="same-origin"
+            ></iframe>
+        </div>
+    </div>
+</body>
+</html>
+HTML 200
+}
+
+(dev_env) {
+    import environment_banner dev #c62828 #fdeaea
+}
+
+(stage_env) {
+    import environment_banner stage #ef6c00 #fff2e3
+}
+
+(env_banner_dev) {
+    import dev_env
+}
+
+(env_banner_stage) {
+    import stage_env
+}
+
+# =============================================================================
 # SECURITY HEADERS
 # =============================================================================
 (security_headers) {

--- a/sites/example-with-snippets.caddy.example
+++ b/sites/example-with-snippets.caddy.example
@@ -177,3 +177,30 @@ shop.example.com {
 #     import cloudns_dns
 #     import maintenance_mode
 # }
+
+# =============================================================================
+# EXAMPLE 7: Environment Banner Wrapper
+# =============================================================================
+# This wraps top-level browser navigations in a visible environment banner while
+# proxying the app itself directly inside an iframe.
+#
+# Notes:
+# - Intended for browser-based dev/stage environments.
+# - The snippet removes X-Frame-Options and Content-Security-Policy headers from
+#   framed app responses so the app can render inside the wrapper.
+# - API clients, assets, WebSockets, and iframe navigations still reach your
+#   normal handlers directly.
+#
+# dev.example.com {
+#     import ssl_defaults
+#     import security_headers
+#     import dev_env
+#     reverse_proxy http://127.0.0.1:8080
+# }
+#
+# stage.example.com {
+#     import ssl_defaults
+#     import security_headers
+#     import stage_env
+#     reverse_proxy http://127.0.0.1:8080
+# }


### PR DESCRIPTION
## Summary by Sourcery

Introduce reusable environment banner snippets to visually wrap non-production environments in a framed HTML shell while delegating actual app handling to existing site routes.

New Features:
- Add generic environment_banner snippet that renders a top-level HTML frame with an environment banner and embeds the app via an iframe.
- Add dev_env and stage_env snippets that configure environment-specific colors and labels for development and staging environments.
- Expose env_banner_dev and env_banner_stage snippets as simple entrypoints to enable the respective environment banners in site configs.

<!-- kumpeapps-issue-autoclose -->
Closes #32