### PR TITLE
[feature/#32] Fixed dev/stage

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,6 +5,7 @@
 
 	# Global error handling for all sites
 	# Shows custom error pages automatically without needing to add them to each site
+	order injection after encode
 	servers {
 		protocols h1 h2 h3
 	}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN xcaddy build \
     --with github.com/caddy-dns/cloudns@v1.1.0 \
     --with github.com/mholt/caddy-ratelimit@v0.1.0 \
     --with github.com/stardothosting/caddy-altcha@e4f123b \
-    --with pkg.jsn.cam/caddy-defender=github.com/JasonLovesDoggo/caddy-defender@v0.10.0
+    --with pkg.jsn.cam/caddy-defender=github.com/JasonLovesDoggo/caddy-defender@v0.10.0 \
+    --with github.com/toowoxx/caddy2-html-injection-plugin@v0.8.0
 
 FROM caddy:2.11.2
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
@@ -25,6 +26,7 @@ COPY sites/defender.example /usr/local/share/caddy/defender.example
 COPY sites/_snippets.inc /usr/local/share/caddy/_snippets.inc
 COPY sites/_matchers.inc /usr/local/share/caddy/_matchers.inc
 COPY sites/example-with-snippets.caddy.example /usr/local/share/caddy/example-with-snippets.caddy.example
+COPY sites/global-assets /usr/local/share/caddy/sites/global-assets
 COPY error-pages /usr/local/share/caddy/error-pages
 COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 COPY safe-reload.sh /usr/bin/safe-reload.sh

--- a/sites/_snippets.inc
+++ b/sites/_snippets.inc
@@ -23,148 +23,30 @@
 # =============================================================================
 # ENVIRONMENT BANNERS
 # =============================================================================
- # Wrap top-level browser HTML navigations in a visible environment frame while
- # letting the site's normal handlers, including reverse_proxy, serve the app.
+ # Inject a visible top banner and colored border into HTML responses while
+ # keeping normal routing and reverse_proxy behavior unchanged.
  # Usage:
  #     import dev_env
  #     reverse_proxy http://127.0.0.1:8080
 (environment_banner) {
-    @environment_banner_frame path /_env_frame/*
-
-    @environment_banner_page {
+    @environment_banner_html {
         method GET
-        not path /_env_frame/*
-        header Sec-Fetch-Dest document
         header Accept *text/html*
     }
 
-    # Route iframe requests to the normal site handlers after stripping the
-    # internal prefix used by the wrapper page.
-    uri @environment_banner_frame strip_prefix /_env_frame
-
-    # Allow the framed application to render even if the upstream sets headers
-    # that would block same-origin embedding.
-    header @environment_banner_frame -X-Frame-Options
-    header @environment_banner_frame -Content-Security-Policy
-
-    respond @environment_banner_page <<HTML
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex,nofollow">
-    <title>{args[0]} Environment</title>
-    <style>
-        :root {
-            color-scheme: light;
-            --env-accent: {args[1]};
-            --env-accent-soft: {args[2]};
-            --env-text: #1b1b1b;
-            --env-surface: #fffaf7;
-        }
-
-        * {
-            box-sizing: border-box;
-        }
-
-        html,
-        body {
-            margin: 0;
-            min-height: 100%;
-            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(180deg, var(--env-accent-soft) 0%, #ffffff 160px);
-            color: var(--env-text);
-        }
-
-        body {
-            border: 8px solid var(--env-accent);
-        }
-
-        .env-shell {
-            min-height: 100vh;
-            display: grid;
-            grid-template-rows: auto 1fr;
-        }
-
-        .env-banner {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1rem;
-            padding: 0.85rem 1.25rem;
-            background: var(--env-accent);
-            color: #ffffff;
-            font-size: 0.95rem;
-            font-weight: 700;
-            letter-spacing: 0.04em;
-            text-transform: uppercase;
-            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
-        }
-
-        .env-banner strong {
-            font-size: 1rem;
-        }
-
-        .env-banner span {
-            opacity: 0.92;
-        }
-
-        .env-app {
-            min-height: 0;
-            padding: 0;
-        }
-
-        .env-app iframe {
-            display: block;
-            width: 100%;
-            height: calc(100vh - 66px);
-            border: 0;
-            background: #ffffff;
-        }
-
-        @media (max-width: 720px) {
-            body {
-                border-width: 6px;
-            }
-
-            .env-banner {
-                align-items: flex-start;
-                flex-direction: column;
-                padding: 0.9rem 1rem;
-            }
-
-            .env-app iframe {
-                height: calc(100vh - 92px);
-            }
-        }
-    </style>
-</head>
-<body>
-    <div class="env-shell">
-        <div class="env-banner">
-            <strong>{args[0]} environment</strong>
-            <span>Use this instance for testing only.</span>
-        </div>
-        <div class="env-app">
-            <iframe
-                src="/_env_frame{uri}"
-                title="{args[0]} environment application"
-                referrerpolicy="same-origin"
-            ></iframe>
-        </div>
-    </div>
-</body>
-</html>
-HTML 200
+    injection @environment_banner_html {
+        inject {args[1]}
+        before "</body>"
+        content_type ^text/html$
+    }
 }
 
 (dev_env) {
-    import environment_banner dev #c62828 #fdeaea
+    import environment_banner dev /usr/local/share/caddy/sites/global-assets/dev-env-banner.html
 }
 
 (stage_env) {
-    import environment_banner stage #ef6c00 #fff2e3
+    import environment_banner stage /usr/local/share/caddy/sites/global-assets/stage-env-banner.html
 }
 
 (env_banner_dev) {
@@ -556,9 +438,8 @@ HTML 200
 # MAINTENANCE MODE
 # =============================================================================
 (maintenance_mode) {
-    respond "We're currently performing maintenance. Please check back soon!" 503 {
-        header Retry-After "3600"
-    }
+    header Retry-After "3600"
+    respond "We're currently performing maintenance. Please check back soon!" 503
 }
 
 # =============================================================================

--- a/sites/example-with-snippets.caddy.example
+++ b/sites/example-with-snippets.caddy.example
@@ -181,15 +181,12 @@ shop.example.com {
 # =============================================================================
 # EXAMPLE 7: Environment Banner Wrapper
 # =============================================================================
-# This wraps top-level browser navigations in a visible environment banner while
-# proxying the app itself directly inside an iframe.
+# This injects a visible environment banner and colored border into HTML pages.
 #
 # Notes:
 # - Intended for browser-based dev/stage environments.
-# - The snippet removes X-Frame-Options and Content-Security-Policy headers from
-#   framed app responses so the app can render inside the wrapper.
-# - API clients, assets, WebSockets, and iframe navigations still reach your
-#   normal handlers directly.
+# - Works with your normal reverse_proxy config below the snippet import.
+# - Requires the caddy2-html-injection-plugin in the Caddy binary.
 #
 # dev.example.com {
 #     import ssl_defaults

--- a/sites/global-assets/dev-env-banner.html
+++ b/sites/global-assets/dev-env-banner.html
@@ -1,0 +1,60 @@
+<style>
+    :root {
+        --env-accent: #c62828;
+        --env-soft: #fdeaea;
+        --env-text: #ffffff;
+    }
+
+    html {
+        box-shadow: inset 0 0 0 6px var(--env-accent);
+    }
+
+    body {
+        padding-top: 46px !important;
+        background-image: linear-gradient(180deg, var(--env-soft), transparent 160px);
+        background-attachment: fixed;
+    }
+
+    #env-banner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 2147483647;
+        height: 46px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        background: var(--env-accent);
+        color: var(--env-text);
+        font: 700 13px/1 "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        pointer-events: none;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+    }
+
+    #env-banner strong {
+        font-size: 14px;
+    }
+
+    @media (max-width: 720px) {
+        html {
+            box-shadow: inset 0 0 0 4px var(--env-accent);
+        }
+
+        body {
+            padding-top: 54px !important;
+        }
+
+        #env-banner {
+            height: 54px;
+            text-align: center;
+            padding: 0 12px;
+            font-size: 12px;
+            line-height: 1.2;
+        }
+    }
+</style>
+<div id="env-banner" aria-hidden="true"><strong>Dev</strong><span>Environment</span></div>

--- a/sites/global-assets/stage-env-banner.html
+++ b/sites/global-assets/stage-env-banner.html
@@ -1,0 +1,60 @@
+<style>
+    :root {
+        --env-accent: #ef6c00;
+        --env-soft: #fff2e3;
+        --env-text: #ffffff;
+    }
+
+    html {
+        box-shadow: inset 0 0 0 6px var(--env-accent);
+    }
+
+    body {
+        padding-top: 46px !important;
+        background-image: linear-gradient(180deg, var(--env-soft), transparent 160px);
+        background-attachment: fixed;
+    }
+
+    #env-banner {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 2147483647;
+        height: 46px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        background: var(--env-accent);
+        color: var(--env-text);
+        font: 700 13px/1 "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        pointer-events: none;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+    }
+
+    #env-banner strong {
+        font-size: 14px;
+    }
+
+    @media (max-width: 720px) {
+        html {
+            box-shadow: inset 0 0 0 4px var(--env-accent);
+        }
+
+        body {
+            padding-top: 54px !important;
+        }
+
+        #env-banner {
+            height: 54px;
+            text-align: center;
+            padding: 0 12px;
+            font-size: 12px;
+            line-height: 1.2;
+        }
+    }
+</style>
+<div id="env-banner" aria-hidden="true"><strong>Stage</strong><span>Environment</span></div>


### PR DESCRIPTION
<!-- kumpeapps-issue-autoclose -->
Closes #32

## Summary by Sourcery

Inject environment banners directly into HTML responses instead of using an iframe wrapper, and bundle shared banner assets into the image.

New Features:
- Add HTML injection-based environment banners for dev and stage environments using external banner templates.

Enhancements:
- Replace the iframe-based environment frame with a lightweight top banner and border injection mechanism that preserves normal routing.
- Adjust maintenance mode responses to always include a Retry-After header.
- Include shared global banner assets in the container image and reference them from Caddy snippets.

Build:
- Extend the custom Caddy build to include the HTML injection plugin required for environment banner insertion.