### PR TITLE
Feature/#32

### DIFF
--- a/sites/_snippets.inc
+++ b/sites/_snippets.inc
@@ -28,20 +28,41 @@
         not host *.stage.* *.dev.*
     }
 
+    # Keep maintenance page assets available while maintenance is active.
+    handle /error-assets/* {
+        uri strip_prefix /error-assets
+        root * /usr/local/share/caddy/error-pages
+        file_server
+    }
+
     handle @maintenance_all {
-        import maintenance_mode
+        header Retry-After "3600"
+        error 503
     }
 
     handle @maintenance_stage {
-        import maintenance_mode
+        header Retry-After "3600"
+        error 503
     }
 
     handle @maintenance_dev {
-        import maintenance_mode
+        header Retry-After "3600"
+        error 503
     }
 
     handle @maintenance_prod {
-        import maintenance_mode
+        header Retry-After "3600"
+        error 503
+    }
+
+    handle_errors {
+        @maintenance expression {http.error.status_code} == 503
+
+        handle @maintenance {
+            rewrite * /maintenance.html
+            root * /usr/local/share/caddy/error-pages
+            file_server
+        }
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Configure Caddy to serve a dedicated maintenance page and assets when maintenance mode is active.

Enhancements:
- Serve maintenance error page assets from a shared error-pages directory during maintenance windows.
- Return HTTP 503 with a Retry-After header for maintenance routes instead of importing the previous maintenance_mode snippet.
- Route 503 errors through a centralized error handler that rewrites to a static maintenance.html page.

<!-- kumpeapps-issue-autoclose -->
Closes #32